### PR TITLE
increase access for travis

### DIFF
--- a/cf_templates/bootstrap.yml
+++ b/cf_templates/bootstrap.yml
@@ -33,4 +33,4 @@ Resources:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/job-function/SystemAdministrator
+        - arn:aws:iam::aws:policy/AdministratorAccess


### PR DESCRIPTION
SystemAdministrator policy does not allow access to cloudformation
functionality. Travis needs that to validate and deploy CF templates.
In the future CI will also manage VPC, DBs, and just about everything
in AWS.