### PR TITLE
Add Dynamodb resources for bridge

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -59,3 +59,39 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/ReadOnlyAccess'
+  AWSSNSDynamoTopic:
+    Type: "AWS::SNS::Topic"
+    Properties:
+      Subscription:
+        -
+          Endpoint: bridgeops@sagebase.org
+          Protocol: email
+  AWSCWDynmoGetRecordsErrorAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSDynamoTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      MetricName: SystemErrors
+      Namespace: AWS/DynamoDB
+      Dimensions:
+        -
+          "Name": "Operation"
+          "Value": "GetRecords"
+      Period: 900
+      Statistic: Maximum
+      Threshold: 1
+  AWSCWDynamoDashboard:
+    Type: 'AWS::CloudWatch::Dashboard'
+    Properties:
+      DashboardBody: !Join
+        - ''
+        - - >-
+            {"widgets": [
+            {"type":"metric", "x":0, "y":0, "width":12, "height":6, "properties":
+            {"metrics":[
+            [ "AWS/DynamoDB", "SystemErrors", "Operation", "GetRecords", {"stat": "Sum"}]],
+            "view": "timeSeries", "stacked": true, "period":300, "stat":"Sum",
+            "region":"us-east-1", "title":"DynamoErrors"}}]}


### PR DESCRIPTION
Create the following dynamo db resources:
* Dashboard to display dynamo SystemErrors metric[1]
* Alarm when there is are SystemErrors
* A SNS topic with an email endpoint for the alarm

[1] https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/dynamo-metricscollected.html