### PR TITLE
IT-239: Enforce multi factor authentication

### DIFF
--- a/cf_templates/bootstrap.yml
+++ b/cf_templates/bootstrap.yml
@@ -23,7 +23,112 @@ Outputs:
     Value: !GetAtt AWSIAMTravisUserAccessKey.SecretAccessKey
     Export:
       Name: !Sub '${AWS::StackName}-TravisUserSecretAccessKey'
+  AWSIAMEnforceMfaPolicy:
+    Value: !Ref AWSIAMEnforceMfaPolicy
+    Export:
+      Name: !Sub '${AWS::StackName}-EnforceMfaPolicy'
 Resources:
+  AWSIAMEnforceMfaPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowAllUsersToListAccounts
+            Effect: Allow
+            Action:
+              - 'iam:ListAccountAliases'
+              - 'iam:ListUsers'
+              - 'iam:GetAccountSummary'
+            Resource: '*'
+          - Sid: AllowIndividualUserToSeeAndManageOnlyTheirOwnAccountInformation
+            Effect: Allow
+            Action:
+              - 'iam:ChangePassword'
+              - 'iam:CreateAccessKey'
+              - 'iam:CreateLoginProfile'
+              - 'iam:DeleteAccessKey'
+              - 'iam:DeleteLoginProfile'
+              - 'iam:GetAccountPasswordPolicy'
+              - 'iam:GetLoginProfile'
+              - 'iam:ListAccessKeys'
+              - 'iam:UpdateAccessKey'
+              - 'iam:UpdateLoginProfile'
+              - 'iam:ListSigningCertificates'
+              - 'iam:DeleteSigningCertificate'
+              - 'iam:UpdateSigningCertificate'
+              - 'iam:UploadSigningCertificate'
+              - 'iam:ListSSHPublicKeys'
+              - 'iam:GetSSHPublicKey'
+              - 'iam:DeleteSSHPublicKey'
+              - 'iam:UpdateSSHPublicKey'
+              - 'iam:UploadSSHPublicKey'
+            Resource: !Join
+              - ''
+              - - 'arn:aws:iam::'
+                - !Ref 'AWS::AccountId'
+                - 'user/${aws:username}'
+          - Sid: AllowIndividualUserToListOnlyTheirOwnMFA
+            Effect: Allow
+            Action:
+              - 'iam:ListVirtualMFADevices'
+              - 'iam:ListMFADevices'
+            Resource:
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                - !Ref 'AWS::AccountId'
+                  - ':mfa/*'
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref 'AWS::AccountId'
+                  - ':user/${aws:username}'
+          - Sid: AllowIndividualUserToManageTheirOwnMFA
+            Effect: Allow
+            Action:
+              - 'iam:CreateVirtualMFADevice'
+              - 'iam:DeleteVirtualMFADevice'
+              - 'iam:RequestSmsMfaRegistration'
+              - 'iam:FinalizeSmsMfaRegistration'
+              - 'iam:EnableMFADevice'
+              - 'iam:ResyncMFADevice'
+            Resource:
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref 'AWS::AccountId'
+                  - ':mfa/${aws:username}'
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref 'AWS::AccountId'
+                  - ':user/${aws:username}'
+          - Sid: AllowIndividualUserToDeactivateOnlyTheirOwnMFAOnlyWhenUsingMFA
+            Effect: Allow
+            Action:
+              - 'iam:DeactivateMFADevice'
+            Resource:
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref 'AWS::AccountId'
+                  - ':mfa/${aws:username}'
+              - !Join
+                - ''
+                - - 'arn:aws:iam::'
+                  - !Ref 'AWS::AccountId'
+                  - ':user/${aws:username}'
+            Condition:
+              Bool:
+                'aws:MultiFactorAuthPresent': 'true'
+          - Sid: BlockAnyAccessOtherThanAboveUnlessSignedInWithMFA
+            Effect: Deny
+            NotAction: 'iam:*'
+            Resource: '*'
+            Condition:
+              BoolIfExists:
+                'aws:MultiFactorAuthPresent': 'false'
   AWSIAMTravisUserAccessKey:
     Type: 'AWS::IAM::AccessKey'
     Properties:
@@ -38,3 +143,4 @@ Resources:
     Properties:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
+        - !Ref AWSIAMEnforceMfaPolicy


### PR DESCRIPTION
Setup AWS policy to enforce MFA on Bridge account. The policy for this
is from the AWS tutorial[1].

[1] https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_users-self-manage-mfa-and-creds.html#tutorial_mfa_step1