### PR TITLE
Restrict logging service access

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -89,11 +89,27 @@ Resources:
     Type: 'AWS::IAM::AccessKey'
     Properties:
       UserName: !Ref AWSIAMSumoLogicUser
+  IAMLoggingServiceManagedPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+            Action:
+              - 's3:Get*'
+              - 's3:List*'
+            Effect: Allow
+            Resource:
+              - !Join
+                - '-'
+                - - arn:aws:s3:::elasticbeanstalk
+                  - !Ref AWS::Region
+                  - !Ref AWS::AccountId
   AWSIAMLoggingServiceGroup:
     Type: 'AWS::IAM::Group'
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+        - !Ref IAMLoggingServiceManagedPolicy
   AWSIAMNewRelicBudgetPolicy:
     Type: "AWS::IAM::Policy"
     Properties:


### PR DESCRIPTION
The Logging Service Group (aka Sumo logic) does not need access to
all buckets, it only  needs access to the elastic beanstalk bucket[1]
(i.e. elasticbeanstalk-region-account-id). Create a custom access policy
for to restrict access only to that bucket.

[1] https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.logging.html#health-logs-s3location