### PR TITLE
Validate CF template on PR

### DIFF
--- a/deploy_infra.sh
+++ b/deploy_infra.sh
@@ -4,13 +4,16 @@
 echo "Validating cloudformation templates..."
 aws cloudformation validate-template --template-body file://cf_templates/bridge.yml
 
-# Handle message that shouldn't be an error, https://github.com/hashicorp/terraform/issues/5653
-echo "Deploy cloudformation templates..."
-message=$(./update_cf_stack.sh 2>&1 1>/dev/null)
-error_code=$(echo $?)
-if [[ $error_code -ne 0 && $message =~ .*"No updates are to be performed".* ]]; then
-  echo "No stack changes detected. An update is not required."
-  exit 0
+# Deploy cloudformation template when PR merges or on a direct push
+if [[ "$TRAVIS_PULL_REQUEST" = "false" ]]; then
+    echo "Deploy cloudformation templates..."
+    # Handle message that shouldn't be an error, https://github.com/hashicorp/terraform/issues/5653
+    message=$(./update_cf_stack.sh 2>&1 1>/dev/null)
+    error_code=$(echo $?)
+    if [[ $error_code -ne 0 && $message =~ .*"No updates are to be performed".* ]]; then
+      echo "No stack changes detected. An update is not required."
+      exit 0
+    fi
+    echo $message
+    exit $error_code
 fi
-echo $message
-exit $error_code


### PR DESCRIPTION
Currently Travis does not run a build when there is a PR. This change
allows us turn on CF template validate when a PR is submitted.
Deployment of the CF template will only occur when the PR is merge or
when there is a direct push.