### PR TITLE
Fix EB logs access

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -101,10 +101,12 @@ Resources:
             Effect: Allow
             Resource:
               - !Join
-                - '-'
-                - - arn:aws:s3:::elasticbeanstalk
+                - ''
+                - - arn:aws:s3:::elasticbeanstalk-
                   - !Ref AWS::Region
+                  - -
                   - !Ref AWS::AccountId
+                  - /*
   AWSIAMLoggingServiceGroup:
     Type: 'AWS::IAM::Group'
     Properties:


### PR DESCRIPTION
Allow logging service group to access EB logs folder and all sub
folders.