### PR TITLE
Fix logging service managed policy

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -125,15 +125,11 @@ Resources:
                 - ''
                 - - 'arn:aws:s3:::'
                   - !Ref AWSS3CloudtrailBucket
-                  - '/AWSLogs/'
-                  - !Ref AWS::AccountId
                   - '/*'
               - !Join
                 - ''
                 - - 'arn:aws:s3:::'
                   - !Ref AWSS3CloudtrailBucket
-                  - '/AWSLogs/'
-                  - !Ref AWS::AccountId
   AWSIAMLoggingServiceGroup:
     Type: 'AWS::IAM::Group'
     Properties:


### PR DESCRIPTION
Sumo likes the policy to be 'arn:aws:s3:::$BUCKET_NAME' instead
of 'arn:aws:s3:::$BUCKET_NAME/AWSLogs/$ACCOUNT_ID' otherwis it
complained about not having the listing permission on the bucket.