### PR TITLE
remove cloudtrail IsMultiRegionTrail param

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -237,7 +237,6 @@ Resources:
       SnsTopicName: !GetAtt AWSSNSCloudtrailTopic.TopicName
       IsLogging: true
       EnableLogFileValidation: true
-      IsMultiRegionTrail: true
   # dynamodb monitoring resources
   AWSSNSDynamoTopic:
     Type: "AWS::SNS::Topic"


### PR DESCRIPTION
enabling IsMultiRegionTrail causes CF deployment to fail with error
"Multi-Region trail must include global service events".