### PR TITLE
Setup a developer user group

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -57,6 +57,14 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
+  AWSIAMDeveloperUsersGroup:
+    Type: 'AWS::IAM::Group'
+    Properties:
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/PowerUserAccess
+        - arn:aws:iam::aws:policy/IAMReadOnlyAccess
+        - !Ref AWSIAMEnforceMfaPolicy
+        - !Ref AWSIAMDynamoDenyDeletePolicy
   AWSIAMPowerUsersGroup:
     Type: 'AWS::IAM::Group'
     Properties:
@@ -81,6 +89,18 @@ Resources:
             Action:
               - "sts:AssumeRole"
       Path: "/"
+  AWSIAMDynamoDenyDeletePolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          -
+            Effect: Deny
+            Action:
+              - dynamodb:DeleteItem
+              - dynamodb:DeleteTable
+            Resource: "*"
   AWSIAMAdminRolePolicy:
     Type: "AWS::IAM::Policy"
     Properties:


### PR DESCRIPTION
Setup a developer user group that allows developers access to AWS
resources.  The only restriction is to deny deletion of dynamo
tables/items and modificaiton of IAM resources.