### PR TITLE
Remove DDB DeleteItem from deny list

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -107,7 +107,6 @@ Resources:
           -
             Effect: Deny
             Action:
-              - dynamodb:DeleteItem
               - dynamodb:DeleteTable
             Resource: "*"
   AWSIAMAdminRolePolicy:


### PR DESCRIPTION
There's no reason to deny developers from deleting DDB items. In fact, this is sometimes necessary for ops and testing.