### PR TITLE
BRIDGE-2041: revoke access to update dynamo tables

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -108,6 +108,8 @@ Resources:
           -
             Effect: Deny
             Action:
+              # UpdateTable operation retricts deletion of indexes
+              - dynamodb:UpdateTable
               - dynamodb:DeleteTable
             Resource: "*"
   AWSIAMRdsDenyDeletePolicy:


### PR DESCRIPTION
The only way to restrict deletion of dynamodb indexes is to
deny the UpdateTable operation.  Users will now need to elevate
to the admin role to update dynamodb tables.