### PR TITLE
add lambda invocation policy

### DIFF
--- a/cf_templates/bridge.yml
+++ b/cf_templates/bridge.yml
@@ -612,6 +612,13 @@ Resources:
         -
           Endpoint: !GetAtt AWSLambaCloudformationFunction.Arn
           Protocol: lambda
+  AWSLambdaCloudformationNotifyInvokePermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      FunctionName: !GetAtt AWSLambaCloudformationFunction.Arn
+      Action: 'lambda:InvokeFunction'
+      Principal: sns.amazonaws.com
+      SourceArn: !Ref AWSSNSCloudformationNotifyLambdaTopic
   # dynamodb monitoring resources
   AWSSNSDynamoTopic:
     Type: "AWS::SNS::Topic"


### PR DESCRIPTION
The lambda to monitor cloudformation deployments would not trigger
because it was missing a policy to allow SNS to invoke it.