### PR TITLE
Get template before creating stack

### DIFF
--- a/config/prod/guardduty-member.yaml
+++ b/config/prod/guardduty-member.yaml
@@ -3,6 +3,8 @@ stack_name: guardduty-member
 dependencies:
   - bootstrap
 hooks:
+  before_create:
+    - !cmd "aws --profile {{ var.profile }} s3 cp s3://{{ environment_variable.AdminCentralInfraCfBucket }}/aws-infra/master/GuardDutyMember.yaml ./remote-templates/GuardDutyMember.yaml"
   before_update:
     - !cmd "aws --profile {{ var.profile }} s3 cp s3://{{ environment_variable.AdminCentralInfraCfBucket }}/aws-infra/master/GuardDutyMember.yaml ./remote-templates/GuardDutyMember.yaml"
 parameters:


### PR DESCRIPTION
We need to get the template from admincentral account before
we can create the stack.