### PR TITLE
remove instance profile

### DIFF
--- a/templates/bridge.yaml
+++ b/templates/bridge.yaml
@@ -209,13 +209,6 @@ Resources:
       Roles:
         -
           !Ref AWSIAMAdminRole
-  AWSIAMInstanceProfile:
-    Type: "AWS::IAM::InstanceProfile"
-    Properties:
-      Path: "/"
-      Roles:
-        -
-          !Ref "AWSIAMAdminRole"
   # resources for logging services
   AWSIAMSumoLogicUser:
     Type: 'AWS::IAM::User'


### PR DESCRIPTION
The admin role is not mean to be used with EC2 instances so we
remove the instance profile.