### PR TITLE
update statistics for sms spend alarm

### DIFF
--- a/templates/bridge.yaml
+++ b/templates/bridge.yaml
@@ -687,7 +687,7 @@ Resources:
       MetricName: SMSMonthToDateSpentUSD
       Namespace: AWS/SNS
       Period: 300
-      Statistic: Average
+      Statistic: Maximum
       TreatMissingData: notBreaching
   AWSCWSmsDashboard:
     Type: 'AWS::CloudWatch::Dashboard'


### PR DESCRIPTION
AWS doc says that the a valid statistic for SMSMonthToDateSpentUSD
metric is 'Maximum'.

ref: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/sns-metricscollected.html