### PR TITLE
[it-395] Fix aws config non-compliance

### DIFF
--- a/templates/bridge.yaml
+++ b/templates/bridge.yaml
@@ -28,6 +28,10 @@ Parameters:
     Description: The AWS account running the Sophos-VPN
     AllowedPattern: '[0-9]*'
     ConstraintDescription: Must be account number without dashes
+  CentralCloudtrailBucket:
+    Type: String
+    Description: The central S3 bucket where AWS CloudTrail send logs to.
+    Default: essentials-awss3cloudtrailbucket-1jz6pf8dzid7r
 Conditions:
   CreateProdResources: !Equals [ !Ref AwsAccount, prod ]
 Resources:
@@ -550,7 +554,7 @@ Resources:
       CloudWatchLogsLogGroupArn: !GetAtt AWSLogsCloudtrailLogGroup.Arn
       CloudWatchLogsRoleArn: !GetAtt AWSIAMCloudtrailLogRole.Arn
       # send all logs to cloudtrail bucket in AWS logcentral account
-      S3BucketName: "essentials-awss3cloudtrailbucket-1jz6pf8dzid7r"
+      S3BucketName: !Ref CentralCloudtrailBucket
       SnsTopicName: !GetAtt AWSSNSCloudtrailTopic.TopicName
       IsLogging: true
       EnableLogFileValidation: true
@@ -630,7 +634,7 @@ Resources:
       Description: Checks whether AWS CloudTrail is enabled.
       InputParameters:
         # logs and data are in AWS logcentral account
-        s3BucketName: "essentials-awss3configbucket-9n8wjykhvr5z"
+        S3BucketName: !Ref CentralCloudtrailBucket
         snsTopicArn: !Ref AWSSNSCloudtrailTopic
         cloudWatchLogsLogGroupArn: !GetAtt AWSLogsCloudtrailLogGroup.Arn
       Scope: {}


### PR DESCRIPTION
AWS config reports non-compliance in all our aws accounts due to
a misconfigured aws config rule.

In each aws account we have setup cloudtrail to send logs to a
central S3 bucket in our aws org-sagebase-logcentral account
(essentials-awss3cloudtrailbucket-1jz6pf8dzid7r). However the
aws config rule was setup to look for the cloudtrail logs in a
local bucket.

To fix the issue we re-configure the config rule to look for
logs in the central s3 bucket.