### PR TITLE
[BRIDGE-2313] Setup DirectPublishToPhoneNumberFailure alarm

### DIFF
--- a/templates/bridge.yaml
+++ b/templates/bridge.yaml
@@ -720,6 +720,29 @@ Resources:
       Period: 300
       Statistic: Maximum
       TreatMissingData: notBreaching
+  AWSCWDirectPublishToPhoneNumberFailureAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AWSSNSSmsTopic
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 3
+      EvaluationPeriods: 12
+      Namespace: AWS/Logs
+      MetricName: DirectPublishToPhoneNumberFailure
+      Dimensions:
+        -
+          "Name": "LogGroupName"
+          "Value": !Join
+            - '/'
+            - - 'sns'
+              - !Ref AWS::Region
+              - !Ref AWS::AccountId
+              - 'DirectPublishToPhoneNumber/Failure'
+      Period: 300
+      Statistic: Average
+      TreatMissingData: notBreaching
   AWSCWSmsDashboard:
     Type: 'AWS::CloudWatch::Dashboard'
     Properties:
@@ -728,7 +751,7 @@ Resources:
         - - >-
             {"widgets": [{ "type":"metric", "x":0, "y":0, "width":12,
             "height":6, "properties":{"metrics":[[ "AWS/SNS",
-            "SMSMonthToDateSpentUSD"]],
+            "SMSMonthToDateSpentUSD", {"stat": "Maximum"}]],
           - >-
             "view": "timeSeries", "stacked": true, "period":300,
             "stat":"Average", "region":"us-east-1",
@@ -737,10 +760,19 @@ Resources:
             {"type":"metric", "x":0, "y":0, "width":12, "height":6,
             "properties":{"metrics":[[ "AWS/SNS", "NumberOfNotificationsFailed",
             "PhoneNumber","PhoneNumberDirect
-          - '"]],'
+          - '", {"stat": "Average"}]],'
           - >-
             "view": "timeSeries", "stacked": true, "period":300,
-            "region":"us-east-1", "title":"NumberOfNotificationsFailed"}}]}
+            "region":"us-east-1", "title":"NumberOfNotificationsFailed"}},
+          - >-
+            {"type":"metric", "x":0, "y":0, "width":12, "height":6,
+            "properties":{"metrics":[[ "AWS/Logs", "DirectPublishToPhoneNumberFailure",
+            "LogGroupName","
+          - !Join [ "/", [ "sns", !Ref "AWS::Region", !Ref "AWS::AccountId", "DirectPublishToPhoneNumber/Failure" ] ]
+          - '", {"stat": "Average"}]],'
+          - >-
+            "view": "timeSeries", "stacked": true, "period":300,
+            "region":"us-east-1", "title":"DirectPublishToPhoneNumberFailure"}}]}
   # S3 bucket for android apps
   AWSS3AndroidAppBucket:
     Type: AWS::S3::Bucket


### PR DESCRIPTION
Add a alarm to notify when there are failures to publish
SMS messages to phone numbers. Also added a dashboard view
for this metric.