### PR TITLE
Adding a user who can only PUT to the documents S3 bucket

### DIFF
--- a/templates/bridge.yaml
+++ b/templates/bridge.yaml
@@ -276,6 +276,20 @@ Resources:
     Type: 'AWS::IAM::AccessKey'
     Properties:
       UserName: !Ref AWSIAMSumoLogicUser
+  AWSS3PutDocumentPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action: 's3:PutObject'
+            Effect: Allow
+            Resource:
+              - !Join
+                - ''
+                - - 'arn:aws:s3:::'
+                  - !Ref AWSS3DocumentsBucket
+                  - '/*'
   IAMLoggingServiceManagedPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:

--- a/templates/bridge.yaml
+++ b/templates/bridge.yaml
@@ -140,7 +140,11 @@ Resources:
       LoginProfile:
         Password: !Ref InitNewUserPassword
         PasswordResetRequired: true
-       
+  AWSIAMS3DocPutUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Policies:
+        - !Ref AWSS3PutDocumentPolicy
   AWSIAMDeveloperUsersGroup:
     Type: 'AWS::IAM::Group'
     Properties:


### PR DESCRIPTION
For this: https://sagebionetworks.jira.com/browse/BRIDGE-2581

As part of this process, the server will return a presigned URL to upload a file to the documents folder in S3. I want to sign that URL with credentials that can only put into that bucket.

I think I also need to attach this policy to the documents folder when it is created in a stack:

{
    "Version": "2012-10-17",
    "Id": "Policy20160803001",
    "Statement": [
        {
            "Sid": "Stmt20160803001",
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:GetObject",
            "Resource": "arn:aws:s3:::docs-${environment}.sagebridge.org/*"
        }
    ]
}