### PR TITLE
fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ stages:
 jobs:
   include:
     - stage: validate
-      script: cfn-lint ./templates/**/*
+      script: cfn-lint ./templates/**/*.yaml
     - stage: deploy
       script: sceptre launch $TRAVIS_BRANCH --yes
 

--- a/templates/bridge.yaml
+++ b/templates/bridge.yaml
@@ -478,6 +478,11 @@ Resources:
       LogGroupName: !Sub '/aws/cloudtrail/${AWS::StackName}.log'
       RetentionInDays: 90
   AWSS3CloudtrailBucket:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - W3011
     DeletionPolicy: Retain
     Type: "AWS::S3::Bucket"
     Properties: {}
@@ -803,6 +808,11 @@ Resources:
             "region":"us-east-1", "title":"DirectPublishToPhoneNumberFailure"}}]}
   # S3 bucket for android apps
   AWSS3AndroidAppBucket:
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - W3011
     Type: AWS::S3::Bucket
     Condition: CreateProdResources
     Properties:


### PR DESCRIPTION
New version of cfn-lint has a new warning rule (W3011)  that broke the
build.  We can ignore this warning as suggested in issue https://github.com/aws-cloudformation/cfn-python-lint/issues/1265