### PR TITLE
[IT-913] Update BridgeProd developer permissions

### DIFF
--- a/templates/iam-policies.yaml
+++ b/templates/iam-policies.yaml
@@ -27,8 +27,43 @@ Resources:
               - 's3:DeleteObject'
             Effect: Allow
             Resource: "arn:aws:s3:::ios-apps.sagebridge.org/*"
+  DynamoDenyDeletePolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          -
+            Effect: Deny
+            Action:
+              # UpdateTable operation retricts deletion of indexes
+              - dynamodb:UpdateTable
+              - dynamodb:DeleteTable
+            Resource: "*"
+  RdsDenyDeletePolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          -
+            Effect: Deny
+            Action:
+              - rds:DeleteDBCluster
+              - rds:DeleteDBClusterSnapshot
+              - rds:DeleteDBInstance
+              - rds:DeleteDBSnapshot
+            Resource: "*"
 Outputs:
   iOSBucketManagedPolicyArn:
     Value: !Ref iOSBucketManagedPolicy
     Export:
       Name: !Sub '${AWS::Region}-${AWS::StackName}-iOSBucketManagedPolicyArn'
+  DynamoDenyDeletePolicyArn:
+    Value: !Ref DynamoDenyDeletePolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-DynamoDenyDeletePolicyArn'
+  RdsDenyDeletePolicyArn:
+    Value: !Ref iOSBucketManagedPolicy
+    Export:
+      Name: !Sub '${AWS::Region}-${AWS::StackName}-RdsDenyDeletePolicyArn'

--- a/templates/prod/jumpcloud-idp.yaml
+++ b/templates/prod/jumpcloud-idp.yaml
@@ -51,6 +51,8 @@ Resources:
       RoleName: !GetAtt BridgeprodDeveloperSamlProvider.Name
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
+        - 'Fn::ImportValue': !Sub '${AWS::Region}-iam-policies-DynamoDenyDeletePolicyArn'
+        - 'Fn::ImportValue': !Sub '${AWS::Region}-iam-policies-RdsDenyDeletePolicyArn'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
This PR is to implement request by bridge team.

Bridge Prod permissions:
* alx and dwayne have admin permissions (no restrictions)
* alx, dwayne and interns have developer permissions (no
restrictions, except:
 no write access to IAM
 no delete access to dynamo
 no delete access to rds

No changes to Bridge Dev account.
* alx and dwayne have admin permissions(no restrictions)
* everyone else has developer permissions (no restrictions
except:
  no write access to IAM