### PR TITLE
[IT-1003] & [IT-1004] setup VPN access to bridge resources

### DIFF
--- a/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
+++ b/config/prod/tgw-spoke-BridgeServer2-vpc.yaml
@@ -1,0 +1,21 @@
+template_path: "remote/transit-gateway-spoke.yaml"
+stack_name: "tgw-spoke-BridgeServer2-vpc"
+stack_tags:
+  Department: "Platform"
+  Project: "Bridge"
+  OwnerEmail: "bridgeIT@sagebase.org"
+dependencies:
+  - "prod/BridgeServer2-vpc.yaml"
+parameters:
+  TransitGatewayEndpointCidr: "10.50.0.0/16"
+  VpcRouteTableId: !stack_output_external BridgeServer2-vpc::PrivateRouteTable
+  VpcId: !stack_output_external BridgeServer2-vpc::VPCId
+  SubnetIds:
+    - !stack_output_external BridgeServer2-vpc::PrivateSubnet
+    - !stack_output_external BridgeServer2-vpc::PrivateSubnet1
+    - !stack_output_external BridgeServer2-vpc::PrivateSubnet2
+  # shared TGW, https://github.com/Sage-Bionetworks/transit-infra/blob/master/templates/transit-gateway.j2
+  TransitGatewayId: "tgw-0004e7e3454cacac5"
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/transit-gateway-spoke.yaml --create-dirs -o templates/remote/transit-gateway-spoke.yaml"


### PR DESCRIPTION
This setup will allow using the new AWS client VPN to access private resources
in the production BridgeServer2-vpc

depends on Sage-Bionetworks/transit-infra#23