### PR TITLE
BridgeDev developers permissions

### DIFF
--- a/templates/develop/jumpcloud-idp.yaml
+++ b/templates/develop/jumpcloud-idp.yaml
@@ -51,6 +51,13 @@ Resources:
       RoleName: !GetAtt BridgedevDeveloperSamlProvider.Name
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/PowerUserAccess
+        - arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
+        - arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess
+        - arn:aws:iam::aws:policy/AmazonRDSFullAccess
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - arn:aws:iam::aws:policy/AmazonSESFullAccess
+        - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+        - arn:aws:iam::aws:policy/AmazonSQSFullAccess
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
BridgeDev developers need access to several various AWS Services. This is the Dev account, so there's no risk to production data. Preferably get this pushed out Friday or Monday so that Kelly can access her test data in AWS.