### PR TITLE
[IT-1053] Remove obsolete VPC and peering

### DIFF
--- a/config/develop/bridge-develop.yaml
+++ b/config/develop/bridge-develop.yaml
@@ -1,7 +1,0 @@
-template_path: aws-default-vpc.yaml
-stack_name: vpc-bridge-develop
-dependencies:
-  - develop/bridge.yaml
-parameters:
-  VpcSubnetPrefix: "172.47"
-  VpcName: bridge-develop

--- a/config/develop/peer-vpn-bridge-develop.yaml
+++ b/config/develop/peer-vpn-bridge-develop.yaml
@@ -1,8 +1,0 @@
-template_path: peer-route-config-defaultvpc.yaml
-stack_name: peer-vpn-bridge-develop
-dependencies:
-  - develop/bridge-develop.yaml
-parameters:
-  PeeringConnectionId: pcx-735aa01b
-  VpcPublicRouteTable: rtb-f333578f
-  VpnCidr: 10.1.0.0/16


### PR DESCRIPTION
bridge-develp vpc was created (a long time ago) as a mirror for the old bridge
prod vpc that only contained public subnets. It was created with the intention
of moving bridgedev env to the AWS bridge dev account. Since then @DwayneJengSage
moved bridge app into a new prod VPC with public & private subnets. The new
"BridgeServer2-develop-vpc" was created to mirror that new prod VPC. That means
that "bridge-develop" vpc is obsolete. To clear up the confusion I we delete
the obsolete "bridge-develop" vpc and its peering connection.