### PR TITLE
[IT-1053] peering to BridgeServer2-develop-vpc

### DIFF
--- a/config/develop/peer-vpn-BridgeServer2-develop.yaml
+++ b/config/develop/peer-vpn-BridgeServer2-develop.yaml
@@ -1,0 +1,13 @@
+template_path: remote/peer-route-config.yaml
+stack_name: peer-vpn-BridgeServer2-develop
+# comment out because can't find the template that creates "BridgeServer2-develop-vpc"
+#dependencies:
+#  - develop/BridgeServer2-vpc.yaml
+parameters:
+  PeeringConnectionId: pcx-093bfdc449a159fe3
+  VpcPrivateRouteTable: rtb-011def3defa2902a7
+  VpcPublicRouteTable: rtb-0b8c6e99798ff3d90
+  VpnCidr: 10.1.0.0/16
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/peer-route-config.yaml --create-dirs -o templates/remote/peer-route-config.yaml"


### PR DESCRIPTION
Peering will allow access to BridgeServer2-develop-vpc resources
from the Sage VPN.

depends on https://github.com/Sage-Bionetworks/admincentral-infra/pull/103
and also depends on configuration of sophos VPN.