### PR TITLE
Add Bridge VPC to develop

### DIFF
--- a/config/develop/BridgeServer2-vpc.yaml
+++ b/config/develop/BridgeServer2-vpc.yaml
@@ -1,0 +1,10 @@
+template_path: remote/vpc.yaml
+stack_name: BridgeServer2-vpc
+dependencies:
+  - develop/bootstrap.yaml
+parameters:
+  VpcName: BridgeServer2-develop-vpc
+  VpcSubnetPrefix: "172.48"
+hooks:
+  before_launch:
+    - !cmd "curl https://{{stack_group_config.admincentral_cf_bucket}}.s3.amazonaws.com/aws-infra/master/vpc.yaml --create-dirs -o templates/remote/vpc.yaml"

--- a/config/develop/bridge.yaml
+++ b/config/develop/bridge.yaml
@@ -3,7 +3,7 @@ stack_name: bridge
 dependencies:
   - develop/essentials.yaml
 parameters:
-  AwsAccount: {{ environment_variable.TRAVIS_BRANCH }}
+  AwsAccount: develop
   AwsDefaultVpcId: "vpc-f389e98a"
   NewRelicAccountId: "754728514883"
   NewRelicExternalId: !ssm /infra/NewRelicExternalId

--- a/config/develop/peer-vpn-BridgeServer2-develop.yaml
+++ b/config/develop/peer-vpn-BridgeServer2-develop.yaml
@@ -1,8 +1,7 @@
 template_path: remote/peer-route-config.yaml
 stack_name: peer-vpn-BridgeServer2-develop
-# comment out because can't find the template that creates "BridgeServer2-develop-vpc"
-#dependencies:
-#  - develop/BridgeServer2-vpc.yaml
+dependencies:
+  - develop/BridgeServer2-vpc.yaml
 parameters:
   PeeringConnectionId: pcx-093bfdc449a159fe3
   VpcPrivateRouteTable: rtb-011def3defa2902a7

--- a/config/prod/bridge.yaml
+++ b/config/prod/bridge.yaml
@@ -3,7 +3,7 @@ stack_name: bridge
 dependencies:
   - prod/essentials.yaml
 parameters:
-  AwsAccount: {{ environment_variable.TRAVIS_BRANCH }}
+  AwsAccount: prod
   AwsDefaultVpcId: "vpc-9c70bbf9"
   NewRelicAccountId: "754728514883"
   NewRelicExternalId: !ssm /infra/NewRelicExternalId


### PR DESCRIPTION
VPC was tested locally and is already in our BridgeDev AWS account. These templates (should) match what's currently in AWS.